### PR TITLE
feat: added import path fixing script for python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,14 @@ python:
 	rm -rf ${GEN_SRC_PYTHON}
 	mkdir -p $(GEN_SRC_PYTHON)
 	protoc --proto_path=$(PROTO_PATH) --python_out=$(GEN_SRC_PYTHON) $(SRC)
+	@echo ""
+	@echo "#####################################################################################################"
+	@echo "TODO for python protobuf"
+	@echo "0. Copy the generated python protobuf files to your repository"
+	@echo "1. Copy 'protobuf_importpath_change.py' to root of your repository"
+	@echo "2. Execute 'python protobuf_importpath_change.py -p [package_path]'. (Like iamport.protobuf_messages)"
+	@echo "#####################################################################################################"
+	@echo ""
 
 .PHONY: dart
 dart:

--- a/protobuf_importpath_change.py
+++ b/protobuf_importpath_change.py
@@ -1,0 +1,48 @@
+import argparse
+import re
+import os
+
+
+def revise_unit_content(content_string, import_path):
+    res = ""
+    compiled_regex = re.compile(r"from\s(.*?)\simport\s.*?_pb2")
+    for unit_line in content_string.split('\n'):
+        match_res = compiled_regex.match(unit_line)
+        if match_res:
+            package_name = match_res.group(1)
+            replaced_line = unit_line.replace(" {} ".format(package_name), " {}.{} ".format(import_path, package_name))
+            res += '\n' + replaced_line
+
+        else:
+            res += '\n' + unit_line
+
+    return res + '\n'
+
+def iterate_members(import_path):
+    rootpath = import_path.replace('.', '/')
+
+    for subdir, dirs, files in os.walk(rootpath):
+        for unit_file in files:
+            if unit_file.endswith('.py'):
+                file_path = os.path.join('.', subdir, unit_file)
+                print(file_path)
+                f = open(file_path, 'r')
+                contents = f.read()
+                f.close()
+
+                revised_contents = revise_unit_content(contents, import_path)
+                f = open(file_path, 'w')
+                f.write(revised_contents)
+                f.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Import path organizer for protobuf-compiled package')
+    parser.add_argument('-p', '--absolute-package-path', dest='absolute_package_path', action='store', type=str, required=True,
+                                help='''absolute packge path.
+                                eg) If the compiled protobuf file is stored in "iamport/protobuf_messages", you may input 'iamport.protobuf_messages' ''')
+
+    args = parser.parse_args()
+
+    iterate_members(args.absolute_package_path)
+


### PR DESCRIPTION
### As-is
- Import path of compiled protobuf doesn't work properly in python
- Apply workaround (force manipulation in package header...) fails
- The best solution is relative import but the level of directory hiearchy are same among packages

### To-be
- Provided python script fixes the import path of compiled protobuf files
- Change import path as absolute path from package root